### PR TITLE
Added capability to Import-CrmSolution with hold option, fixed false positive on Import-CrmSolution and added new capability to promote hold CRM solution upgrade

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -446,7 +446,12 @@ function Set-CrmRecord{
             }           
         }
 
+        try{
         $existingRecord = Get-CrmRecord -conn $conn -EntityLogicalName $entityLogicalName -Id $id -Fields $retrieveFields.ToArray() -ErrorAction SilentlyContinue
+        }
+        catch{
+                # do nothing just continue. If the caller has try catch this will prevent this exception caught by the callers try catch
+            }
 
         if($existingRecord.original -eq $null)
         {


### PR DESCRIPTION
1. Added capability to Import-CrmSolution as hold solution
2. Fixed issue of giving false positive on Import-CrmSolution success when it fails without proper error thrown from CRM #114 
3. Apply Solution Upgrade capability added with DeleteAndPromote-CrmSolution this allows to upgrade a hold solution https://community.dynamics.com/crm/b/crminogic/archive/2016/01/25/solution-patching-in-microsoft-dynamics-crm-2016