### PR TITLE
"PrimaryKeyField" parameter for function "Set-CrmRecord"

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -436,11 +436,11 @@ function Set-CrmRecord{
     # 'PrimaryKeyField' is an options parameter and is used for custom activity entities
     if(-not [string]::IsNullOrEmpty($PrimaryKeyField)) 
     {
-         $primaryKeyField = $PrimaryKeyField;
+         $primaryKeyField = $PrimaryKeyField
     }
     else
     {
-        $primaryKeyField = GuessPrimaryKeyField -EntityLogicalName $entityLogicalName;
+        $primaryKeyField = GuessPrimaryKeyField -EntityLogicalName $entityLogicalName
     }
 
     # If upsert specified


### PR DESCRIPTION
Extends the function "Set-CrmRecord" with an additional parameter that
allows us to pass in the primary-key-field as string. This way is it
possible to perform update operation for custom activity entities or any
other entity where the primary-key-field does not follow the standard
convention ("<%entity-logical-name.%>id")