### PR TITLE
Add parameters to Get/Set-CrmUserMailbox

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -3585,10 +3585,13 @@ function Get-CrmUserMailbox{
     <attribute name="enabledforincomingemail" />
     <attribute name="enabledforact" />
     <attribute name="emailaddress" />
+    <attribute name="emailrouteraccessapproval" />
+    <attribute name="isemailaddressapprovedbyo365admin" />
     <attribute name="processanddeleteemails" />
     <attribute name="processinglastattemptedon" />
     <attribute name="actstatus" />
     <attribute name="actdeliverymethod" />
+    <attribute name="testemailconfigurationscheduled" />
     <attribute name="allowemailconnectortousecredentials" />
     <filter type="and">
       <condition attribute="regardingobjectid" operator="eq" value="{$UserId}" />
@@ -4654,6 +4657,18 @@ function Set-CrmUserMailbox {
         [int]$OutgoingEmailDeliveryMethod,
         [parameter(Mandatory=$false, ParameterSetName="Custom")]
         [int]$ACTDeliveryMethod,
+        [parameter(Mandatory=$false, ParameterSetName="Custom")]
+        [int]$EmailRouterAccessApproval,
+        [parameter(Mandatory=$false, ParameterSetName="Custom")]
+        [bool]$IsEmailAddressApprovedByO365Admin,
+        [parameter(Mandatory=$false, ParameterSetName="Custom")]
+        [bool]$TestEmailConfigurationScheduled,
+        [parameter(Mandatory=$false, ParameterSetName="Custom")]
+        [bool]$EnabledForACT,
+        [parameter(Mandatory=$false, ParameterSetName="Custom")]
+        [bool]$EnabledForIncomingEmail,
+        [parameter(Mandatory=$false, ParameterSetName="Custom")]
+        [bool]$EnabledForOutgoingEmail,
         [parameter(Mandatory=$false, ParameterSetName="Default")]
         [switch]$ApplyDefaultEmailSettings
     )
@@ -4675,6 +4690,7 @@ function Set-CrmUserMailbox {
         $updateFields.Add("incomingemaildeliverymethod", (New-CrmOptionSetValue $xml.ChildNodes.IncomingEmailDeliveryMethod))
         $updateFields.Add("outgoingemaildeliverymethod", (New-CrmOptionSetValue $xml.ChildNodes.OutgoingEmailDeliveryMethod))
         $updateFields.Add("actdeliverymethod", (New-CrmOptionSetValue $xml.ChildNodes.ACTDeliveryMethod))
+        $updateFields.Add("emailrouteraccessapproval", (New-CrmOptionSetValue $xml.ChildNodes.EmailRouterAccessApproval))
     }
     foreach($parameter in $MyInvocation.BoundParameters.GetEnumerator())
     {   
@@ -4686,7 +4702,7 @@ function Set-CrmUserMailbox {
         {
             $updateFields.Add($parameter.Key.ToLower(), (New-CrmEntityReference emailserverprofile $parameter.Value))
         }
-        elseif($parameter.Key -in ("IncomingEmailDeliveryMethod","OutgoingEmailDeliveryMethod","ACTDeliveryMethod"))
+        elseif($parameter.Key -in ("IncomingEmailDeliveryMethod","OutgoingEmailDeliveryMethod","ACTDeliveryMethod","EmailRouterAccessApproval"))
         {
             $updateFields.Add($parameter.Key.ToLower(), (New-CrmOptionSetValue $parameter.Value))
         }


### PR DESCRIPTION
Addresses issue #179

Adds the following parameters to Set-CrmUserMailbox:

`Set-CrmUserMailbox -EmailRouterAccessApproval`
Sets the status of the email address.

`Set-CrmUserMailbox -IsEmailAddressApprovedByO365Admin`
Sets the status of approval of the email address by O365 Admin.

`Set-CrmUserMailbox -TestEmailConfigurationScheduled`
Set the email configuration test flag for schedule for a mailbox record.

`Set-CrmUserMailbox -EnabledForACT`
Sets whether the mailbox is enabled for Appointments, Contacts, and Tasks.

`Set-CrmUserMailbox -EnabledForIncomingEmail`
Sets whether the mailbox is enabled for receiving email.

`Set-CrmUserMailbox -EnabledForOutgoingEmail`
Sets whether the mailbox is enabled for sending email.


Adds the following parameters to Get-CrmUserMailbox:

`Get-UserCrmMailbox -emailrouteraccessapproval`
Shows the status of the email address.

`Get-UserCrmMailbox -isemailaddressapprovedbyo365admin`
Shows the status of approval of the email address by O365 Admin.