### PR TITLE
Added an EntityReference Property to each returned record (via multip…

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -195,87 +195,6 @@ function Connect-CrmOnPremDiscovery{
     }
 }
 
-function MapFieldTypeByFieldValue {
-    PARAM(
-        [Parameter(Mandatory=$true)]
-        [object]$Value
-    )
-
-    $valueTypeToCrmTypeMapping = @{
-        "Boolean" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmBoolean;
-        "DateTime" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmDateTime;
-        "Decimal" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmDecimal;
-        "Single" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmFloat;
-        "Money" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw;
-        "Int32" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmNumber;
-        "EntityReference" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw;
-        "OptionSetValue" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw;
-        "String" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::String;
-        "Guid" =  [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::UniqueIdentifier;
-    }
-
-    # default is RAW
-    $crmDataType = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw
-
-    if($Value -ne $null) {
-
-        $valueType = $Value.GetType().Name
-        
-        if($valueTypeToCrmTypeMapping.ContainsKey($valueType)) {
-            $crmDataType = $valueTypeToCrmTypeMapping[$valueType]
-        }   
-    }
-
-    return $crmDatatype
-}
-
-function GuessPrimaryKeyField() {
-    PARAM(
-        [Parameter(Mandatory=$true)]
-        [object]$EntityLogicalName
-    )
-
-    $standardActivityEntities = @(
-        "opportunityclose",
-        "socialactivity",
-        "campaignresponse",
-        "letter","orderclose",
-        "appointment",
-        "recurringappointmentmaster",
-        "fax",
-        "email",
-        "activitypointer",
-        "incidentresolution",
-        "bulkoperation",
-        "quoteclose",
-        "task",
-        "campaignactivity",
-        "serviceappointment",
-        "phonecall"
-    )
-
-    # Some Entity has different pattern for id name.
-    if($EntityLogicalName -eq "usersettings")
-    {
-        $primaryKeyField = "systemuserid"
-    }
-    elseif($EntityLogicalName -eq "systemform")
-    {
-        $primaryKeyField = "formid"
-    }
-    elseif($EntityLogicalName -in $standardActivityEntities)
-    {
-        $primaryKeyField = "activityid"
-    }
-    else 
-    {
-        # default
-        $primaryKeyField = $EntityLogicalName + "id"
-    }
-    
-    $primaryKeyField
-}
-
 function New-CrmRecord{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -386,7 +305,6 @@ function Get-CrmRecord{
 New-Alias -Name Update-CrmRecord -Value Set-CrmRecord
 
 #UpdateEntity 
-
 function Set-CrmRecord{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
 
@@ -748,7 +666,6 @@ function Set-CrmRecord{
 }
 
 #DeleteEntity 
-
 function Remove-CrmRecord{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -790,9 +707,7 @@ function Remove-CrmRecord{
     }
 }
 
-### Other Cmdlets from Xrm Tooling ###
 #AddEntityToQueue 
-
 function Move-CrmRecordToQueue{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -834,7 +749,6 @@ function Move-CrmRecordToQueue{
 }
 
 #AssignEntityToUser
-
 function Set-CrmRecordOwner{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -897,7 +811,6 @@ function Set-CrmRecordOwner{
 }
 
 #CloseActivity 
-
 function Set-CrmActivityRecordToCloseState{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -936,7 +849,6 @@ function Set-CrmActivityRecordToCloseState{
 }
 
 #CreateAnnotation 
-
 function Add-CrmNoteToCrmRecord{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -985,7 +897,6 @@ function Add-CrmNoteToCrmRecord{
 }
 
 #CreateEntityAssociation
-
 function Add-CrmRecordAssociation{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -3674,9 +3585,6 @@ function Get-CrmUserMailbox{
     return $psobj
 }
 
-<#LEFT OFF HERE#> 
-# .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
-
 function Get-CrmUserPrivileges{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
 
@@ -4933,7 +4841,7 @@ function Set-CrmRecordAccess {
     }
 }
 
-### Get CRM Types object ###
+### CRM Types ###
 function New-CrmMoney{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
  [CmdletBinding()]
@@ -4977,7 +4885,7 @@ function New-CrmEntityReference{
     return $crmEntityReference
 }
 
-### Performance Test cmdlets ###
+### Performance Tests ###
 function Test-CrmViewPerformance{
 # .ExternalHelp Microsoft.Xrm.Data.PowerShell.Help.xml
     [CmdletBinding()]
@@ -5143,6 +5051,86 @@ function VerifyCrmConnectionParam {
     }
 	return $conn
 }
+function MapFieldTypeByFieldValue {
+    PARAM(
+        [Parameter(Mandatory=$true)]
+        [object]$Value
+    )
+
+    $valueTypeToCrmTypeMapping = @{
+        "Boolean" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmBoolean;
+        "DateTime" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmDateTime;
+        "Decimal" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmDecimal;
+        "Single" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmFloat;
+        "Money" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw;
+        "Int32" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::CrmNumber;
+        "EntityReference" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw;
+        "OptionSetValue" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw;
+        "String" = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::String;
+        "Guid" =  [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::UniqueIdentifier;
+    }
+
+    # default is RAW
+    $crmDataType = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw
+
+    if($Value -ne $null) {
+
+        $valueType = $Value.GetType().Name
+        
+        if($valueTypeToCrmTypeMapping.ContainsKey($valueType)) {
+            $crmDataType = $valueTypeToCrmTypeMapping[$valueType]
+        }   
+    }
+
+    return $crmDatatype
+}
+function GuessPrimaryKeyField() {
+    PARAM(
+        [Parameter(Mandatory=$true)]
+        [object]$EntityLogicalName
+    )
+
+    $standardActivityEntities = @(
+        "opportunityclose",
+        "socialactivity",
+        "campaignresponse",
+        "letter","orderclose",
+        "appointment",
+        "recurringappointmentmaster",
+        "fax",
+        "email",
+        "activitypointer",
+        "incidentresolution",
+        "bulkoperation",
+        "quoteclose",
+        "task",
+        "campaignactivity",
+        "serviceappointment",
+        "phonecall"
+    )
+
+    # Some Entity has different pattern for id name.
+    if($EntityLogicalName -eq "usersettings")
+    {
+        $primaryKeyField = "systemuserid"
+    }
+    elseif($EntityLogicalName -eq "systemform")
+    {
+        $primaryKeyField = "formid"
+    }
+    elseif($EntityLogicalName -in $standardActivityEntities)
+    {
+        $primaryKeyField = "activityid"
+    }
+    else 
+    {
+        # default
+        $primaryKeyField = $EntityLogicalName + "id"
+    }
+    
+    $primaryKeyField
+}
+
 ## Taken from CRM SDK sample code
 ## https://msdn.microsoft.com/en-us/library/microsoft.crm.sdk.messages.retrieveentityribbonresponse.compressedentityxml.aspx
 function UnzipCrmRibbon {

--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -1519,21 +1519,16 @@ function Get-CrmRecordsByFetch{
 						if($keyName -eq "ReturnProperty_Id "){
 							$keyName = "ReturnProperty_Id"
 						}
-
-						if(!($psobj | gm).Name.Contains($keyName))
-						{
+						if(!($psobj | gm).Name.Contains($keyName)){
 							Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $null
 						}
-						if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference])
-						{
+						if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference]){
 							$psobj.($keyName) = $att.Value.Name
 						}
-						elseif($att.Value -is [Microsoft.Xrm.Sdk.AliasedValue])
-						{
+						elseif($att.Value -is [Microsoft.Xrm.Sdk.AliasedValue]){
 							$psobj.($keyName) = $att.Value.Value
 						}
-						else
-						{
+						else{
 							$psobj.($keyName) = $att.Value
 						}
 					}  
@@ -1546,7 +1541,6 @@ function Get-CrmRecordsByFetch{
 						if($keyName -eq "ReturnProperty_Id "){
 							$keyName = "ReturnProperty_Id"
 						}
-
                         if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference]){
                             Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $att.Value.Name
                         }

--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -1501,11 +1501,9 @@ function Get-CrmRecordsByFetch{
             foreach($record in $records.Values)
             {   
                 $psobj = New-Object -TypeName System.Management.Automation.PSObject
-                if($recordslist.Count -eq 0)
-                {
+                if($recordslist.Count -eq 0){
                     $atts = $xml.GetElementsByTagName('attribute')
-                    foreach($att in $atts)
-                    {
+                    foreach($att in $atts){
                         if($att.ParentNode.HasAttribute('alias')){
                             $attName = $att.ParentNode.GetAttribute('alias') + "." + $att.name
                         }
@@ -1515,52 +1513,47 @@ function Get-CrmRecordsByFetch{
                         Add-Member -InputObject $psobj -MemberType NoteProperty -Name $attName -Value $null
                         Add-Member -InputObject $psobj -MemberType NoteProperty -Name ($attName + "_Property") -Value $null
                     }
-                    foreach($att in $record.GetEnumerator())
-                    {
+                    foreach($att in $record.GetEnumerator()){
 						#BUG where ReturnProperty_Id is returned as "ReturnProperty_Id " <-- with a trailing space
 						$keyName = $att.Key
 						if($keyName -eq "ReturnProperty_Id "){
 							$keyName = "ReturnProperty_Id"
 						}
 
-                        if(!($psobj | gm).Name.Contains($keyName))
-                        {
-                            Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $null
-                        }
-                        if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference])
-                        {
-                            $psobj.($keyName) = $att.Value.Name
-                        }
-				    	elseif($att.Value -is [Microsoft.Xrm.Sdk.AliasedValue])
-				    	{
-				    		$psobj.($keyName) = $att.Value.Value
-				    	}
-                        else
-                        {
-                            $psobj.($keyName) = $att.Value
-                        }
-                    }  
+						if(!($psobj | gm).Name.Contains($keyName))
+						{
+							Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $null
+						}
+						if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference])
+						{
+							$psobj.($keyName) = $att.Value.Name
+						}
+						elseif($att.Value -is [Microsoft.Xrm.Sdk.AliasedValue])
+						{
+							$psobj.($keyName) = $att.Value.Value
+						}
+						else
+						{
+							$psobj.($keyName) = $att.Value
+						}
+					}  
                 }
                 else
                 {
-                    foreach($att in $record.GetEnumerator())
-                    {
+                    foreach($att in $record.GetEnumerator()){
 						#BUG where ReturnProperty_Id is returned as "ReturnProperty_Id " <-- with a trailing space
 						$keyName = $att.Key
 						if($keyName -eq "ReturnProperty_Id "){
 							$keyName = "ReturnProperty_Id"
 						}
 
-                        if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference])
-                        {
+                        if($att.Value -is [Microsoft.Xrm.Sdk.EntityReference]){
                             Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $att.Value.Name
                         }
-				    	elseif($att.Value -is [Microsoft.Xrm.Sdk.AliasedValue])
-				    	{
+				    	elseif($att.Value -is [Microsoft.Xrm.Sdk.AliasedValue]){
 				    		Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $att.Value.Value
 				    	}
-                        else
-                        {
+                        else{
                             Add-Member -InputObject $psobj -MemberType NoteProperty -Name $keyName -Value $att.Value
                         }
                     }  

--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -1498,8 +1498,7 @@ function Get-CrmRecordsByFetch{
         elseif($records.Count -gt 0)
         {
             Write-Debug "Records Found!"
-            foreach($record in $records.Values)
-            {   
+            foreach($record in $records.Values){   
                 $psobj = New-Object -TypeName System.Management.Automation.PSObject
                 if($recordslist.Count -eq 0){
                     $atts = $xml.GetElementsByTagName('attribute')
@@ -1533,8 +1532,7 @@ function Get-CrmRecordsByFetch{
 						}
 					}  
                 }
-                else
-                {
+                else{
                     foreach($att in $record.GetEnumerator()){
 						#BUG where ReturnProperty_Id is returned as "ReturnProperty_Id " <-- with a trailing space
 						$keyName = $att.Key

--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -1502,16 +1502,16 @@ function Get-CrmRecordsByFetch{
                 $psobj = New-Object -TypeName System.Management.Automation.PSObject
                 if($recordslist.Count -eq 0){
                     $atts = $xml.GetElementsByTagName('attribute')
-                    foreach($att in $atts){
-                        if($att.ParentNode.HasAttribute('alias')){
-                            $attName = $att.ParentNode.GetAttribute('alias') + "." + $att.name
-                        }
-                        else{
-                            $attName = $att.name
-                        }
-                        Add-Member -InputObject $psobj -MemberType NoteProperty -Name $attName -Value $null
-                        Add-Member -InputObject $psobj -MemberType NoteProperty -Name ($attName + "_Property") -Value $null
-                    }
+					foreach($att in $atts){
+						if($att.ParentNode.HasAttribute('alias')){
+							$attName = $att.ParentNode.GetAttribute('alias') + "." + $att.name
+						}
+						else{
+							$attName = $att.name
+						}
+						Add-Member -InputObject $psobj -MemberType NoteProperty -Name $attName -Value $null
+						Add-Member -InputObject $psobj -MemberType NoteProperty -Name ($attName + "_Property") -Value $null
+					}
                     foreach($att in $record.GetEnumerator()){
 						#BUG where ReturnProperty_Id is returned as "ReturnProperty_Id " <-- with a trailing space
 						$keyName = $att.Key
@@ -1550,8 +1550,8 @@ function Get-CrmRecordsByFetch{
                         }
                     }  
                 }
-                Add-Member -InputObject $psobj -MemberType NoteProperty -Name "original" -Value $record
-                Add-Member -InputObject $psobj -MemberType NoteProperty -Name "logicalname" -Value $logicalname
+				Add-Member -InputObject $psobj -MemberType NoteProperty -Name "original" -Value $record
+				Add-Member -InputObject $psobj -MemberType NoteProperty -Name "logicalname" -Value $logicalname
 				#adding Dynamic EntityReference
 				if($psobj."ReturnProperty_Id" -ne $null -and $psobj."ReturnProperty_EntityName" -ne $null){
 					Add-Member -InputObject $psobj -MemberType NoteProperty -Name "EntityReference" -Value (New-CrmEntityReference -EntityLogicalName $psobj."ReturnProperty_EntityName" -Id $psobj."ReturnProperty_Id")


### PR DESCRIPTION
Added new property of EntityReference to both get-crmrecord and anything that uses get-crmrecordsbyfetch 

@kenakamu can you review quick?  I think this avoids the function/method that you didn't want to add, but still adds it as a property so it's super easy and simple to get access to. Can you also give it a quick once over to ensure I didn't miss anything?  As far as I know everything pretty much funnels into get-crmrecord or get-crmrecordsbyfetch 