### PR TITLE
Connect crm online assume https

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -76,7 +76,7 @@ function Connect-CrmOnline{
         [parameter(Mandatory=$true)]
         [PSCredential]$Credential, 
         [Parameter(Mandatory=$true)]
-        [ValidatePattern('https://([\w-]+).crm([0-9]*).dynamics.com')]
+        [ValidatePattern('([\w-]+).crm([0-9]*).dynamics.com')]
         [string]$ServerUrl, 
 		[Parameter(Mandatory=$false,ValueFromPipeline)]
         [ValidateScript({
@@ -89,7 +89,10 @@ function Connect-CrmOnline{
         })]
         [string]$ClientId
     )
-   
+	if($ServerUrl.StartsWith('https://') -ne $true){
+		Write-Verbose "ServerUrl is missing https, fixing URL: https://$ServerUrl"
+		$ServerUrl = "https://" + $ServerUrl
+	}
     $userName = $Credential.UserName
     $password = $Credential.GetNetworkCredential().Password
     $connectionString = "AuthType=Office365;RequireNewInstance=True;Username=$userName;Password=$password;Url=$ServerUrl"

--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -89,10 +89,11 @@ function Connect-CrmOnline{
         })]
         [string]$ClientId
     )
-	if($ServerUrl.StartsWith('https://') -ne $true){
+	if($ServerUrl.StartsWith("https://","CurrentCultureIgnoreCase") -ne $true){
 		Write-Verbose "ServerUrl is missing https, fixing URL: https://$ServerUrl"
 		$ServerUrl = "https://" + $ServerUrl
 	}
+	Write-Verbose "Connecting to ServerUrl: $ServerUrl"
     $userName = $Credential.UserName
     $password = $Credential.GetNetworkCredential().Password
     $connectionString = "AuthType=Office365;RequireNewInstance=True;Username=$userName;Password=$password;Url=$ServerUrl"


### PR DESCRIPTION
Always assume CRM Online will use HTTPS - if it's not supplied then prepend it to the serverurl - this also makes it easier to type for the connect-crmonline cmdlet. 