### PR TITLE
fix set-crmrecord date time as null

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -754,8 +754,14 @@ function Set-CrmRecord{
         foreach($field in $Fields.GetEnumerator())
         {  
             $newfield = New-Object -TypeName 'Microsoft.Xrm.Tooling.Connector.CrmDataTypeWrapper'
-            $newfield.Type = MapFieldTypeByFieldValue -Value $field.Value
-        
+            if($field.value -eq $null)
+            {
+                $newfield.Type = [Microsoft.Xrm.Tooling.Connector.CrmFieldType]::Raw
+            }
+            else
+            {
+                $newfield.Type = MapFieldTypeByFieldValue -Value $field.Value
+            }
             $newfield.Value = $field.Value
             $newfields.Add($field.Key, $newfield)
         }


### PR DESCRIPTION
#248 
fixed by setting raw as its type whenever the value is null.