### PR TITLE
change invoke-crmaction over to use a pre pshell v5 constructor approach

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -4028,8 +4028,8 @@ function Invoke-CrmAction {
     }
     process
     {
-        $request = [Microsoft.Xrm.Sdk.OrganizationRequest]::new($Name)
-
+		$request = new-object Microsoft.Xrm.Sdk.OrganizationRequest
+		$request.RequestName = $Name
         if($Target) {
             $request.Parameters.Add("Target", $Target) 
         }


### PR DESCRIPTION
Addressing bug reported in issue: #275 