### PR TITLE
encode password to avoid semi-colon input messing up connection

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -173,7 +173,7 @@ function Connect-CrmOnline{
         if(-not [string]::IsNullOrEmpty($OAuthRedirectUri)){
 		    $cs += ";redirecturi=$OAuthRedirectUri"
         }
-		$cs += ";ClientSecret=$ClientSecret"
+		$cs += ";ClientSecret='$ClientSecret'"
 		Write-Verbose ($cs.Replace($ClientSecret, "*******"))
 		try
 		{


### PR DESCRIPTION
Causes exception with client secrets that contain semi-colons or other special characters. 
```
Exception calling ".ctor" with "1" argument(s): "Object reference not set to an instance of an object."
At C:\Users\seanmcn\Source\GitHub\Microsoft.Xrm.Data.PowerShell\Microsoft.Xrm.Data.PowerShell\Microsoft.Xrm.Data.Powers
hell.psm1:184 char:4
+             $global:conn = [Microsoft.Xrm.Tooling.Connector.CrmServic ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : NullReferenceException
```