### PR TITLE
Fixed issue #525

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -1306,10 +1306,10 @@ function Add-CrmActivityToCrmRecord{
 			foreach($field in $Fields.GetEnumerator())
 			{  
 				$newfield = New-Object -TypeName 'Microsoft.Xrm.Tooling.Connector.CrmDataTypeWrapper'
-                $newfield.Type = MapFieldTypeByFieldValue -Value $field.Value
-                $newfield.Value = $field.Value
-                $newfields.Add($field.Key, $newfield)
-            }
+		                $newfield.Type = MapFieldTypeByFieldValue -Value $field.Value
+		                $newfield.Value = $field.Value
+		                $newfields.Add($field.Key, $newfield)
+		    	}
 		}
 
 		try
@@ -5603,7 +5603,7 @@ function VerifyCrmConnectionParam {
 
 function MapFieldTypeByFieldValue {
     PARAM(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true)][AllowNull()]
         [object]$Value
     )
 


### PR DESCRIPTION
Previously unable to set null column values when Set-CrmRecord command was createing a record. It was failing with the error described in the issue